### PR TITLE
Find Clang avoiding the system (non-ROC) LLVM

### DIFF
--- a/lib/comgr/CMakeLists.txt
+++ b/lib/comgr/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 
 project(code_object_manager)
 
-find_package(Clang REQUIRED CONFIG)
+find_package(Clang REQUIRED CONFIG PATHS ${LLVM_DIR} "/opt/rocm/llvm" NO_DEFAULT_PATH)
 add_definitions(${LLVM_DEFINITIONS})
 include_directories(${LLVM_INCLUDE_DIRS})
 link_directories(${LLVM_LIBRARY_DIRS})


### PR DESCRIPTION
Use NO_DEFAULT_PATH to avoid finding the system (non-ROC) LLVM.
Use /opt/rocm/llvm as an additional hint to be consistent with the build systems of other ROC projects (such as ROCm-OpenCL-Driver)

For a similar change, see https://github.com/RadeonOpenCompute/ROCm-Device-Libs/commit/698cec4790933ecb5e4c1091616f4505134c2b63