### PR TITLE
Set RPATH so libraries are found at runtime

### DIFF
--- a/lib/comgr/CMakeLists.txt
+++ b/lib/comgr/CMakeLists.txt
@@ -3,6 +3,28 @@ cmake_minimum_required(VERSION 3.2.0)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
+#BEGIN RPATH HANDLING
+# use, i.e. don't skip the full RPATH for the build tree
+SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+
+# when building, don't use the install RPATH already
+# (but later on when installing)
+SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+
+SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+
+# add the automatically determined parts of the RPATH
+# which point to directories outside the build tree to the install RPATH
+SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+
+# the RPATH to be used when installing, but only if it's not a system directory
+LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" isSystemDir)
+IF("${isSystemDir}" STREQUAL "-1")
+   SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+ENDIF("${isSystemDir}" STREQUAL "-1")
+#END RPATH HANDLING
+
 # Build ROCM-Compiler-Support with ccache if the package is present.
 set(ROCM_COMPILER_SUPPORT_CCACHE_BUILD OFF CACHE BOOL "Set to ON for a ccache enabled build")
 if(ROCM_COMPILER_SUPPORT_CCACHE_BUILD)


### PR DESCRIPTION
If the RPATH is not set, then link errors occur at runtime as the dynamic linker cannot find the llvm libraries.
For example, `ldd libamd_comgr.so` reports `ibclangFrontend.so.9svn => not found`
By setting the RPATH, the dynamic linker knows where to look for the llvm libraries.

See https://gitlab.kitware.com/cmake/community/wikis/doc/cmake/RPATH-handling