### PR TITLE
Link additional required LLVM libraries

### DIFF
--- a/lib/comgr/CMakeLists.txt
+++ b/lib/comgr/CMakeLists.txt
@@ -207,7 +207,11 @@ install(FILES
   DESTINATION "${AMD_COMGR_PACKAGE_PREFIX}")
 
 set(CLANG_LIBS
-  clangFrontendTool)
+  clangFrontendTool
+  clangFrontend
+  clangBasic
+  clangDriver
+  clangSerialization)
 
 set(LLD_LIBS
   lldELF
@@ -218,8 +222,20 @@ if (LLVM_LINK_LLVM_DYLIB)
 else()
   llvm_map_components_to_libnames(LLVM_LIBS
     ${LLVM_TARGETS_TO_BUILD}
+    Option
     DebugInfoDWARF
-    Symbolize)
+    Symbolize
+    Support
+    Object
+    BitWriter
+    MC
+    MCParser
+    MCDisassembler
+    Core
+    IRReader
+    CodeGen
+    Linker
+    BinaryFormat)
 endif()
 
 target_link_libraries(amd_comgr


### PR DESCRIPTION
Without these additional required dependencies, linking fails with errors such as:
`undefined reference to llvm::errs()'`

Originally reported at:
https://bugs.gentoo.org/711006