### PR TITLE
Ensure Clang/LLVM symbols are exposed for plugins

### DIFF
--- a/lib/comgr/CMakeLists.txt
+++ b/lib/comgr/CMakeLists.txt
@@ -143,8 +143,6 @@ if (UNIX)
     configure_file(
       ${CMAKE_CURRENT_SOURCE_DIR}/src/exportmap.in
       ${CMAKE_CURRENT_BINARY_DIR}/src/exportmap @ONLY)
-    list(APPEND AMD_COMGR_PRIVATE_LINKER_OPTIONS
-      "-Wl,--version-script=${CMAKE_CURRENT_BINARY_DIR}/src/exportmap")
     # When building a shared library with -fsanitize=address we can't be
     # strict about undefined symbol references, as Clang won't include
     # libasan in the link, see
@@ -295,7 +293,8 @@ else()
   llvm_map_components_to_libnames(LLVM_LIBS
     ${LLVM_TARGETS_TO_BUILD}
     DebugInfoDWARF
-    Symbolize)
+    Symbolize
+    )
 endif()
 
 target_link_options(amd_comgr
@@ -305,10 +304,13 @@ target_link_options(amd_comgr
     ${AMD_COMGR_PRIVATE_LINKER_OPTIONS})
 
 target_link_libraries(amd_comgr
-  PRIVATE
+	PUBLIC
+  -Wl,--whole-archive
     ${LLD_LIBS}
     ${LLVM_LIBS}
-    ${CLANG_LIBS})
+    ${CLANG_LIBS}
+    -Wl,--no-whole-archive
+    )
 
 if (NOT UNIX)
   target_link_libraries(amd_comgr


### PR DESCRIPTION
Ideally should also be forward/backported to other relevant ROCM versions.

HIPRtc currently does not correctly support LLVM plugins. Specifically, symbols defined within LLVM and/or clang are not available by any plugins when they are loaded. This is partially due to the fact that the one location with these symbols (libamd_comgr) does not mark these symbols as being available globally when it is loaded.

This patch is the second of two pieces required to support LLVM plugins on ROCm, the first of which is a change to mark libamd_comgr as having its symbols loaded globally (https://github.com/ROCm-Developer-Tools/ROCclr/pull/32).

Specifically, successfully exporting these symbols will result in the following (note the capital T) when built:

```
wsmoses@noether:~/rocm/ROCm-CompilerSupport/lib/comgr/build$ nm libamd_comgr.so.2.4 | grep _ZN4llvm2cl18GenericOptionValue6anchorEv
0000000005677990 T _ZN4llvm2cl18GenericOptionValue6anchorEv
0000000005677990 t _ZN4llvm2cl18GenericOptionValue6anchorEv.localalias.28
```

cc @jedbrown @LeilaGhaffari