### PR TITLE
Fix deprecation warnings for clang

### DIFF
--- a/lib/comgr/include/amd_comgr.h.in
+++ b/lib/comgr/include/amd_comgr.h.in
@@ -51,7 +51,7 @@
 // Add deprecated support for Comgr on both Windows and Linux
 // This can be removed in favor of genereic [[deprecated]] in C23
 #ifndef AMD_COMGR_DEPRECATED
-#ifdef __GNUC__ && __GNUC__ > 5
+#if defined __GNUC__ && (__GNUC__ > 5 || defined __clang__)
 #define AMD_COMGR_DEPRECATED(msg) __attribute__((deprecated(msg)))
 #elif defined(_MSC_VER)
 //#define AMD_COMGR_DEPRECATED(msg) __declspec(deprecated(msg))


### PR DESCRIPTION
The previous implementation would raise a -Wextra-tokens warning and cause clang to skip printing the deprecation warnings.

This commit fixes the warning and makes the check compatible with upstream clang so that warnings are printed properly.